### PR TITLE
Conversion Tag and Global Site Tag report components

### DIFF
--- a/app/src/app/modules/conversion-tag-report/conversion-tag-report.component.css
+++ b/app/src/app/modules/conversion-tag-report/conversion-tag-report.component.css
@@ -1,0 +1,58 @@
+/***************************************************************************
+*
+*  Copyright 2021 Google Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Note that these code samples being shared are not official Google
+*  products and are not formally supported.
+*
+***************************************************************************/
+
+.conversion-tag-report-container {
+    padding: 15px
+}
+
+.table-container {
+    margin: 5px 0 10px 0px;
+}
+
+table {
+    width: 100%;
+}
+
+.filter {
+    font-size: 14px;
+    width: 30%;
+    padding: 15px;
+}
+
+.crop-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.crop-container button {
+    width: 5px;
+    height: 28px;
+    margin-left: 10px;
+}
+
+.crop-container button mat-icon {
+    font-size: 14px;
+}
+
+td.mat-cell {
+    padding: 5px;
+}

--- a/app/src/app/modules/conversion-tag-report/conversion-tag-report.component.html
+++ b/app/src/app/modules/conversion-tag-report/conversion-tag-report.component.html
@@ -1,0 +1,91 @@
+<div class="conversion-tag-report-container">
+    <h1>{{title}}</h1>
+    <mat-divider></mat-divider>
+    <mat-divider></mat-divider>
+    <mat-form-field class="filter">
+        <mat-label>Filter</mat-label>
+        <input matInput (keyup)="applyFilter($event)" placeholder="" #input>
+    </mat-form-field>
+    <div class="table-container mat-elevation-z8">
+        <table mat-table [dataSource]="dataSource" matSort>
+            <!-- Page Column -->
+            <ng-container matColumnDef="page">
+                <th mat-header-cell *matHeaderCellDef mat-sort-header>Page</th>
+                <td mat-cell *matCellDef="let element">
+                    <div class="crop-container">
+                        {{cropURL(element.page)}}
+                        <button mat-raised-button color="primary" (click)="openDialog('Page', element.page)">
+                            <mat-icon>info</mat-icon>
+                        </button>
+                    </div>
+                </td>
+            </ng-container>
+            <!-- Tag Type Column -->
+            <ng-container matColumnDef="tagType">
+                <th mat-header-cell *matHeaderCellDef mat-sort-header>Tag Type</th>
+                <td mat-cell *matCellDef="let element">{{element.tagType}}</td>
+            </ng-container>
+            <!-- Account ID Table Column -->
+            <ng-container matColumnDef="accountId">
+                <th mat-header-cell *matHeaderCellDef mat-sort-header>Account ID</th>
+                <td mat-cell *matCellDef="let element">{{element.accountId}}</td>
+            </ng-container>
+            <!-- gTag Column -->
+            <ng-container matColumnDef="gTag">
+                <th mat-header-cell *matHeaderCellDef>gTag (T/F)</th>
+                <td mat-cell *matCellDef="let element">{{element.gTag}}</td>
+            </ng-container>
+            <!-- Network Call Column -->
+            <ng-container matColumnDef="networkCall">
+                <th mat-header-cell *matHeaderCellDef>Network Call</th>
+                <td mat-cell *matCellDef="let element">
+                    <div class="crop-container">
+                        {{cropURL(element.networkCall)}}
+                        <button mat-raised-button color="primary"
+                            (click)="openDialog('Network Call', element.networkCall)">
+                            <mat-icon>info</mat-icon>
+                        </button>
+                    </div>
+                </td>
+            </ng-container>
+            <!-- Floodlight ID Column -->
+            <ng-container matColumnDef="floodlightId">
+                <th mat-header-cell *matHeaderCellDef>Floodlight ID</th>
+                <td mat-cell *matCellDef="let element">{{element.floodlightId}}</td>
+            </ng-container>
+            <!-- Floodlight Activity Tag Column -->
+            <ng-container matColumnDef="floodlightActivityTag">
+                <th mat-header-cell *matHeaderCellDef>Floodlight Activity Tag</th>
+                <td mat-cell *matCellDef="let element">{{element.floodlightActivityTag}}</td>
+            </ng-container>
+            <!-- Floodlight Activity Group Column -->
+            <ng-container matColumnDef="floodlightActivityGroup">
+                <th mat-header-cell *matHeaderCellDef>Floodlight Activity Group</th>
+                <td mat-cell *matCellDef="let element">{{element.floodlightActivityGroup}}</td>
+            </ng-container>
+            <!-- Floodlight Sales Order Column -->
+            <ng-container matColumnDef="floodlightSalesOrder">
+                <th mat-header-cell *matHeaderCellDef>Floodlight Sales Order</th>
+                <td mat-cell *matCellDef="let element">{{element.floodlightSalesOrder}}</td>
+            </ng-container>
+            <!-- Floodlight uVariables Order Column -->
+            <ng-container matColumnDef="floodlightUVariables">
+                <th mat-header-cell *matHeaderCellDef>Floodlight uVariables</th>
+                <td mat-cell *matCellDef="let element">{{element.floodlightUVariables}}</td>
+            </ng-container>
+            <!-- Warnings Column -->
+            <ng-container matColumnDef="warnings">
+                <th mat-header-cell *matHeaderCellDef>Warnings</th>
+                <td mat-cell *matCellDef="let element">{{element.warnings}}</td>
+            </ng-container>
+            <!-- Errors Column -->
+            <ng-container matColumnDef="errors">
+                <th mat-header-cell *matHeaderCellDef>Errors</th>
+                <td mat-cell *matCellDef="let element">{{element.errors}}</td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        </table>
+        <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+    </div>
+</div>

--- a/app/src/app/modules/conversion-tag-report/conversion-tag-report.component.spec.ts
+++ b/app/src/app/modules/conversion-tag-report/conversion-tag-report.component.spec.ts
@@ -1,0 +1,45 @@
+/***************************************************************************
+*
+*  Copyright 2021 Google Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Note that these code samples being shared are not official Google
+*  products and are not formally supported.
+*
+***************************************************************************/
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ConversionTagReportComponent } from './conversion-tag-report.component';
+
+describe('ConversionTagReportComponent', () => {
+  let component: ConversionTagReportComponent;
+  let fixture: ComponentFixture<ConversionTagReportComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ConversionTagReportComponent]
+    })
+      .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConversionTagReportComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/app/src/app/modules/conversion-tag-report/conversion-tag-report.component.ts
+++ b/app/src/app/modules/conversion-tag-report/conversion-tag-report.component.ts
@@ -1,0 +1,125 @@
+/***************************************************************************
+*
+*  Copyright 2021 Google Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Note that these code samples being shared are not official Google
+*  products and are not formally supported.
+*
+***************************************************************************/
+
+import { Component, ViewChild, OnInit, ChangeDetectorRef, OnDestroy } from '@angular/core';
+import { MatPaginator, MatPaginatorIntl } from '@angular/material/paginator';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatSort } from '@angular/material/sort';
+import { MatDialog } from '@angular/material/dialog';
+import { TagInformation } from '../../models/tag-information';
+import { DialogComponent } from '../dialog/dialog.component';
+import { FloodlightTrackerService } from '../../services/floodlight-tracker.service';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'app-conversion-tag-report',
+  templateUrl: './conversion-tag-report.component.html',
+  styleUrls: ['./conversion-tag-report.component.css']
+})
+export class ConversionTagReportComponent implements OnInit, OnDestroy {
+
+  title: string = 'Conversion Tag Report';
+  displayedColumns: Array<string>;
+  dataSource: MatTableDataSource<TagInformation>
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
+  // Subscription that will be monitoring if a new tag needs to be added
+  // to the table. Used for x-component communication betweem the settings-form component
+  // and the conversion-tag-report component.
+  private addToTableSubscription!: Subscription;
+
+  constructor(private floodlightTracker: FloodlightTrackerService,
+    private changeDetectorRefs: ChangeDetectorRef,
+    public dialog: MatDialog) {
+    this.paginator = new MatPaginator(new MatPaginatorIntl(), ChangeDetectorRef.prototype);
+    this.sort = new MatSort();
+    this.dataSource = new MatTableDataSource<TagInformation>([]);
+    this.displayedColumns = this.buildColumns();
+  }
+
+  ngOnInit(): void {
+    // Create subscription to monitor when a new tag needs to be added to the table.
+    this.addToTableSubscription = this.floodlightTracker.addToTableEmitter
+      .subscribe((tagInformation: TagInformation | undefined) => {
+        if (tagInformation) {
+          var rows = this.dataSource.data;
+          rows.push(tagInformation);
+          this.dataSource.data = rows;
+          // Workaround to update the View 'manually' since it not being updated automatically.
+          // TODO: investigate.
+          this.changeDetectorRefs.detectChanges();
+        } else {
+          // Clear table when undefined, it means that the table needs to be reset.
+          this.dataSource.data = [];
+        }
+      });
+  }
+
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+  }
+
+  ngOnDestroy(): void {
+    // Always destroy the subscription to avoid memory leaks.
+    this.addToTableSubscription.unsubscribe();
+  }
+
+  buildColumns() {
+    return [
+      'page',
+      'tagType',
+      'accountId',
+      'gTag',
+      'networkCall',
+      'floodlightId',
+      'floodlightActivityTag',
+      'floodlightActivityGroup',
+      'floodlightSalesOrder',
+      'floodlightUVariables',
+      'warnings',
+      'errors'
+    ]
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+  }
+
+  cropURL(url: string) {
+    let limit = 30;
+    if (url.length > limit) {
+      url = url.substr(0, limit) + "...";
+    }
+    return url;
+  }
+
+  openDialog(title: string, url: string) {
+    this.dialog.open(DialogComponent, {
+      data: {
+        title: title,
+        url: url
+      }
+    });
+  }
+
+}

--- a/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.css
+++ b/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.css
@@ -1,0 +1,42 @@
+/***************************************************************************
+*
+*  Copyright 2021 Google Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Note that these code samples being shared are not official Google
+*  products and are not formally supported.
+*
+***************************************************************************/
+
+.global-site-tag-report-container {
+    padding: 15px
+}
+
+.table-container {
+    margin: 5px 0 10px 0px;
+}
+
+table {
+    width: 100%;
+}
+
+.filter {
+    font-size: 14px;
+    width: 30%;
+    padding: 15px;
+}
+
+td.mat-cell {
+    padding: 5px;
+}

--- a/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.html
+++ b/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.html
@@ -1,0 +1,31 @@
+<div class="global-site-tag-report-container">
+    <h1>{{title}}</h1>
+    <mat-divider></mat-divider>
+    <mat-divider></mat-divider>
+    <mat-form-field class="filter">
+        <mat-label>Filter</mat-label>
+        <input matInput (keyup)="applyFilter($event)" placeholder="" #input>
+    </mat-form-field>
+    <div class="table-container mat-elevation-z8">
+        <table mat-table [dataSource]="dataSource" matSort>
+            <!-- Url Column -->
+            <ng-container matColumnDef="url">
+                <th mat-header-cell *matHeaderCellDef mat-sort-header>Url</th>
+                <td mat-cell *matCellDef="let element"> {{element.url}} </td>
+            </ng-container>
+            <!-- Account IDs Column -->
+            <ng-container matColumnDef="tags">
+                <th mat-header-cell *matHeaderCellDef mat-sort-header>Account IDs</th>
+                <td mat-cell *matCellDef="let element"> {{element.tags}} </td>
+            </ng-container>
+            <!-- Cookies Table Column -->
+            <ng-container matColumnDef="cookies">
+                <th mat-header-cell *matHeaderCellDef mat-sort-header>Cookies</th>
+                <td mat-cell *matCellDef="let element"> {{element.cookies}} </td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        </table>
+        <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+    </div>
+</div>

--- a/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.spec.ts
+++ b/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.spec.ts
@@ -1,0 +1,45 @@
+/***************************************************************************
+*
+*  Copyright 2021 Google Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Note that these code samples being shared are not official Google
+*  products and are not formally supported.
+*
+***************************************************************************/
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { GlobalSiteTagReportComponent } from './global-site-tag-report.component';
+
+describe('GlobalSiteTagVerificationReportComponent', () => {
+  let component: GlobalSiteTagReportComponent;
+  let fixture: ComponentFixture<GlobalSiteTagReportComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [GlobalSiteTagReportComponent]
+    })
+      .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GlobalSiteTagReportComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.ts
+++ b/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.ts
@@ -1,0 +1,96 @@
+/***************************************************************************
+*
+*  Copyright 2021 Google Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*  Note that these code samples being shared are not official Google
+*  products and are not formally supported.
+*
+***************************************************************************/
+
+import { Component, ViewChild, OnInit, ChangeDetectorRef, OnDestroy } from '@angular/core';
+import { MatPaginator, MatPaginatorIntl } from '@angular/material/paginator';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatSort } from '@angular/material/sort';
+import { GlobalSiteTag } from '../../models/global-site-tag';
+import { GlobalTagVerificationService } from '../../services/global-tag-verification.service';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'app-global-site-tag-report',
+  templateUrl: './global-site-tag-report.component.html',
+  styleUrls: ['./global-site-tag-report.component.css']
+})
+export class GlobalSiteTagReportComponent implements OnInit, OnDestroy {
+
+  title: string = 'Global Site Tag Verification Report';
+  displayedColumns: Array<string>;
+  dataSource: MatTableDataSource<GlobalSiteTag>
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
+  // Subscription that will be monitoring if a new tag needs to be added
+  // to the table. Used for x-component communication between the settings-form component
+  // and the global-site-tag-report component.
+  private addToTableSubscription!: Subscription;
+
+  constructor(private globalTag: GlobalTagVerificationService,
+    private changeDetectorRefs: ChangeDetectorRef) {
+    this.paginator = new MatPaginator(new MatPaginatorIntl(), ChangeDetectorRef.prototype);
+    this.sort = new MatSort();
+    this.dataSource = new MatTableDataSource<GlobalSiteTag>([]);
+    this.displayedColumns = this.buildColumns();
+  }
+
+  ngOnInit(): void {
+    // Create subscription to monitor when a new tag needs to be added to the table.
+    this.addToTableSubscription = this.globalTag.addToTableEmitter
+      .subscribe((tagInformation: GlobalSiteTag | undefined) => {
+        if (tagInformation) {
+          var rows = this.dataSource.data;
+          rows.push(tagInformation);
+          this.dataSource.data = rows;
+          // Workaround to update the View 'manually' since it not being updated automatically.
+          // TODO: investigate.
+          this.changeDetectorRefs.detectChanges();
+        } else {
+          // Clear table when undefined, it means that the table needs to be reset.
+          this.dataSource.data = [];
+        }
+      });
+  }
+
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+  }
+
+  ngOnDestroy(): void {
+    // Always destroy the subscription to avoid memory leaks.
+    this.addToTableSubscription.unsubscribe();
+  }
+
+  buildColumns() {
+    return [
+      'url',
+      'tags',
+      'cookies'
+    ]
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+  }
+
+}


### PR DESCRIPTION
Add the Conversion Tag and the Global Site Tag report components. The components handle the tables that hold the tag information captured from the Chrome extension browser events using the Chrome extension API.