### PR TITLE
Feedback fix

### DIFF
--- a/app/src/app/modules/conversion-tag-report/conversion-tag-report.component.css
+++ b/app/src/app/modules/conversion-tag-report/conversion-tag-report.component.css
@@ -44,8 +44,6 @@ table {
 }
 
 .crop-container button {
-    width: 5px;
-    height: 28px;
     margin-left: 10px;
 }
 
@@ -54,5 +52,9 @@ table {
 }
 
 td.mat-cell {
+    padding: 5px;
+}
+
+th.mat-header-cell {
     padding: 5px;
 }

--- a/app/src/app/modules/conversion-tag-report/conversion-tag-report.component.html
+++ b/app/src/app/modules/conversion-tag-report/conversion-tag-report.component.html
@@ -11,14 +11,7 @@
             <!-- Page Column -->
             <ng-container matColumnDef="page">
                 <th mat-header-cell *matHeaderCellDef mat-sort-header>Page</th>
-                <td mat-cell *matCellDef="let element">
-                    <div class="crop-container">
-                        {{cropURL(element.page)}}
-                        <button mat-raised-button color="primary" (click)="openDialog('Page', element.page)">
-                            <mat-icon>info</mat-icon>
-                        </button>
-                    </div>
-                </td>
+                <td mat-cell *matCellDef="let element">{{element.page}}</td>
             </ng-container>
             <!-- Tag Type Column -->
             <ng-container matColumnDef="tagType">
@@ -40,10 +33,9 @@
                 <th mat-header-cell *matHeaderCellDef>Network Call</th>
                 <td mat-cell *matCellDef="let element">
                     <div class="crop-container">
-                        {{cropURL(element.networkCall)}}
                         <button mat-raised-button color="primary"
                             (click)="openDialog('Network Call', element.networkCall)">
-                            <mat-icon>info</mat-icon>
+                            <mat-icon>info</mat-icon> Details
                         </button>
                     </div>
                 </td>

--- a/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.css
+++ b/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.css
@@ -40,3 +40,7 @@ table {
 td.mat-cell {
     padding: 5px;
 }
+
+th.mat-header-cell {
+    padding: 5px;
+}

--- a/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.html
+++ b/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.html
@@ -18,11 +18,6 @@
                 <th mat-header-cell *matHeaderCellDef mat-sort-header>Account IDs</th>
                 <td mat-cell *matCellDef="let element"> {{element.tags}} </td>
             </ng-container>
-            <!-- Cookies Table Column -->
-            <ng-container matColumnDef="cookies">
-                <th mat-header-cell *matHeaderCellDef mat-sort-header>Cookies</th>
-                <td mat-cell *matCellDef="let element"> {{element.cookies}} </td>
-            </ng-container>
             <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
             <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
         </table>

--- a/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.ts
+++ b/app/src/app/modules/global-site-tag-report/global-site-tag-report.component.ts
@@ -83,8 +83,7 @@ export class GlobalSiteTagReportComponent implements OnInit, OnDestroy {
   buildColumns() {
     return [
       'url',
-      'tags',
-      'cookies'
+      'tags'
     ]
   }
 

--- a/app/src/app/modules/settings-form/settings-form.component.css
+++ b/app/src/app/modules/settings-form/settings-form.component.css
@@ -81,7 +81,7 @@
 
 .card {
     background-color: rgba(0,0,0,.04);
-    width: 570px;
+    width: 60%;
     margin: 35px 0px 15px 0px;
 }
 

--- a/app/src/app/modules/settings-form/settings-form.component.html
+++ b/app/src/app/modules/settings-form/settings-form.component.html
@@ -68,23 +68,11 @@
             </mat-slide-toggle>
         </div>
         <div class="form-item">
-            <label>Reset Global Site Tab Per Webpage</label>
-            <mat-slide-toggle color="accent" formControlName="tagResetEnabled">
-            </mat-slide-toggle>
-        </div>
-        <div class="form-item">
             <label>Pages With No Conversion Tags</label>
             <mat-slide-toggle color="accent" formControlName="showNoFloodlight">
             </mat-slide-toggle>
         </div>
         <mat-card class="card">
-            <mat-card-title>Note</mat-card-title>
-            <p>
-                <strong>gclid</strong> and <strong>gclsrc</strong> values have been generated and
-                will be appended to the starting URL as follows:
-                <strong>https://mysampleurl.com?gclid=<span id="gclid">{{gclid}}</span>&gclsrc=<span
-                        id="gclsrc">{{gclsrc}}</span></strong>
-            </p>
             <mat-card-title>Disclaimer</mat-card-title>
             <p>
                 You may notice a drop in site performance during the audit, this is due to the volume of

--- a/app/src/app/modules/settings-form/settings-form.component.ts
+++ b/app/src/app/modules/settings-form/settings-form.component.ts
@@ -83,7 +83,6 @@ export class SettingsFormComponent implements OnInit {
       'urlFile': new FormControl(''),
       'manualSet': new FormControl(false),
       'verificationEnabled': new FormControl(false),
-      'tagResetEnabled': new FormControl(false),
       'showNoFloodlight': new FormControl(false),
     })
   }
@@ -131,12 +130,10 @@ export class SettingsFormComponent implements OnInit {
   setupGlobalTagVerification(startingUrl: string, domain: string) {
     let verificationEnabled = this.settingsForm.get('verificationEnabled')?.value;
     let manualSet = this.settingsForm.get('manualSet')?.value;
-    let tagResetEnabled = this.settingsForm.get('tagResetEnabled')?.value;
     // Init Global Tag Verification
     this.globalTag.setDomain(domain);
     this.globalTag.setVerificationEnabled(verificationEnabled);
     this.globalTag.setManualSet(manualSet);
-    this.globalTag.setTagResetEnabled(tagResetEnabled);
     // Setup Global Tag Verification
     this.globalTag.globalVerificationReset();
     this.globalTag.clearFirstPartyCookies(startingUrl, domain);
@@ -175,14 +172,14 @@ export class SettingsFormComponent implements OnInit {
     this.crawler.setLoadTime(loadTime);
     this.crawler.setDomain(domain);
     this.crawler.setDiscovery(this.discovery);
-    let tagResetEnabled = this.settingsForm.get('tagResetEnabled')?.value;
     let showNoFloodlight = this.settingsForm.get('showNoFloodlight')?.value;
     let manualSet = this.settingsForm.get('manualSet')?.value;
     if (this.urls && this.urls.length > 0) {
       this.crawler.setUrls(this.urls);
     }
     this.crawler.onBeforeVisit((url: string) => {
-      let cUrl = constructUrl(url, tagResetEnabled, '', '', '');
+      // Send false to includeUserParams for now
+      let cUrl = constructUrl(url, false, '', '', '');
       if (cUrl) {
         this.globalTag.setUrl(cUrl);
       }

--- a/app/src/app/modules/statistics/statistics.component.css
+++ b/app/src/app/modules/statistics/statistics.component.css
@@ -20,7 +20,9 @@
 ***************************************************************************/
 
 .stats-container {
-    padding-left: 15px
+    padding-left: 15px;
+    width: 50%;
+    margin: auto;
 }
 
 .stats-details {
@@ -31,7 +33,6 @@
 
 .card {
     background-color: rgba(0,0,0,.04);
-    width: 570px;
     margin: 5px 0px 15px 15px;
 }
 


### PR DESCRIPTION
Remove Tag Reset field from the form since it is now being used. Remove info button from Page column in the Conversion Tag Report. Remove gclid note. Fix some styling issues. 