### PR TITLE
Update chrome-api.service.ts DOM text reinterpreted as HTML

### DIFF
--- a/app/src/app/services/chrome-api.service.ts
+++ b/app/src/app/services/chrome-api.service.ts
@@ -48,7 +48,7 @@ export class ChromeAPIService {
         return results
 
         function injectCode() {
-            var links = document.documentElement.innerHTML.match(/href="(.*?)"/g);
+            var links = document.documentElement.innerText.match(/href="(.*?)"/g);
             var result = [];
             if (links) {
                 for (var i = 0; i < links.length; i++) {


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.